### PR TITLE
Fix typo in main headline text

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -93,7 +93,7 @@ export default function Home() {
           <div className="w-full">
             {/* Main Headline */}
             <h1 className="text-white text-4xl md:text-5xl lg:text-6xl font-bold leading-tight mb-6 filter drop-shadow-lg">
-              Der Malerx in Winterthur für Präzision, Sauberkeit & Begeisterung
+              Der Maleryx in Winterthur für Präzision, Sauberkeit & Begeisterung
             </h1>
 
             {/* Subheadline */}


### PR DESCRIPTION
Changes the text "Der Malerx in Winterthur" to "Der Maleryx in Winterthur" in the main headline component.

This corrects a typo in the German text displayed on the homepage.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e40e1a4e3d89403f87e5247e1849456c/nova-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e40e1a4e3d89403f87e5247e1849456c</projectId>-->
<!--<branchName>nova-oasis</branchName>-->