### PR TITLE
Update mobile accordion styling and layout

### DIFF
--- a/components/WhyFarbxpressSection.tsx
+++ b/components/WhyFarbxpressSection.tsx
@@ -113,15 +113,18 @@ export function WhyFarbxpressSection({
           </div>
         </div>
 
-        {/* Mobile Layout - Vertical Accordion */}
-        <div className="md:hidden">
-          <div className="bg-white/90 backdrop-blur-sm rounded-xl border border-white/20">
-            <Accordion type="single" collapsible className="space-y-0">
-              {reasonCards.map((card) => (
-                <MobileAccordionItem key={card.id} card={card} />
-              ))}
-            </Accordion>
-          </div>
+        {/* Mobile Layout - Separated Accordion Items */}
+        <div className="md:hidden space-y-4">
+          {reasonCards.map((card) => (
+            <div
+              key={card.id}
+              className="bg-white/90 backdrop-blur-sm rounded-xl border border-white/20"
+            >
+              <Accordion type="single" collapsible>
+                <MobileAccordionItem card={card} />
+              </Accordion>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/components/WhyFarbxpressSection.tsx
+++ b/components/WhyFarbxpressSection.tsx
@@ -67,7 +67,7 @@ export function WhyFarbxpressSection({
   // Mobile accordion item component
   const MobileAccordionItem = ({ card }: { card: (typeof reasonCards)[0] }) => (
     <AccordionItem value={card.id} className="border-none">
-      <AccordionTrigger className="px-6 py-4 text-left hover:no-underline [&[data-state=open]>div>svg]:rotate-45">
+      <AccordionTrigger className="px-6 py-4 text-left hover:no-underline [&>svg]:hidden [&[data-state=open]_.plus-icon]:rotate-45">
         <div className="flex items-center justify-between w-full">
           <div className="flex items-center space-x-4">
             <div className="bg-primary/10 rounded-full p-3 flex-shrink-0">
@@ -78,7 +78,7 @@ export function WhyFarbxpressSection({
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Plus className="h-5 w-5 text-gray-400 transition-transform duration-200" />
+            <Plus className="plus-icon h-5 w-5 text-gray-400 transition-transform duration-200" />
           </div>
         </div>
       </AccordionTrigger>

--- a/components/WhyFarbxpressSection.tsx
+++ b/components/WhyFarbxpressSection.tsx
@@ -66,7 +66,7 @@ export function WhyFarbxpressSection({
 
   // Mobile accordion item component
   const MobileAccordionItem = ({ card }: { card: (typeof reasonCards)[0] }) => (
-    <AccordionItem value={card.id} className="border-white/20">
+    <AccordionItem value={card.id} className="border-none">
       <AccordionTrigger className="px-6 py-4 text-left hover:no-underline [&[data-state=open]>div>svg]:rotate-45">
         <div className="flex items-center justify-between w-full">
           <div className="flex items-center space-x-4">


### PR DESCRIPTION
Updates the mobile accordion component in WhyFarbxpressSection with the following changes:

- Remove border styling from AccordionItem (border-white/20 → border-none)
- Hide default accordion trigger icon and add custom plus-icon class
- Update icon rotation selector to target .plus-icon class specifically
- Restructure mobile layout from single accordion container to individual accordion items
- Wrap each accordion item in its own styled container with spacing
- Add space-y-4 for vertical spacing between accordion items

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e40e1a4e3d89403f87e5247e1849456c/swoosh-garden)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e40e1a4e3d89403f87e5247e1849456c</projectId>-->
<!--<branchName>swoosh-garden</branchName>-->